### PR TITLE
CSS presets for all elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet"  rel= "stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-Avb2QiuDEEvB4bZJYdft2mNjVShBftLdPG8FJ0V7irTLQ8Uo0qcPxh4Plq7G5tGm0rU+1SPhVotteLpBERwTkw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <style>
-        body {
+        * {
             margin:0;
             padding:0;
             font-family: Arial, Helvetica, sans-serif;


### PR DESCRIPTION
### What is the issue here?

From your code, you have set the body tag's style to have a margin of 0px. What this does is, this goes 0 margin i.e. No space between the content and the edges of your browser.

```html
 body {
            margin:0;
            padding:0;
            font-family: Arial, Helvetica, sans-serif;
        }
```

### How does this PR fix it?

 What you actually want is to, set all the elements margin to be 0px. You use Universal selector "*", which selects all the elements from the page and eliminates default margin/padding.

```html
 * {
            margin:0;
            padding:0;
            font-family: Arial, Helvetica, sans-serif;
        }
```
